### PR TITLE
Change HTTPS to HTTP in SITEURL parameter

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 AUTHOR = u'drinkingkazu'
 SITENAME = u'DeepLearnPhysics'
-SITEURL = 'https://deeplearnphysics.org'
+SITEURL = 'http://deeplearnphysics.org'
 #SITEURL = '' #uncomment for local development
 PATH = 'content'
 


### PR DESCRIPTION
Fix SSL issue : Github pages don't support yet HTTPS with custom domain names. Thus use the HTTP URL to access static assets such as JS/CSS.